### PR TITLE
Fix fencing generation for arced traces

### DIFF
--- a/via_fence_generator/viafence.py
+++ b/via_fence_generator/viafence.py
@@ -373,7 +373,8 @@ def getCircleCenterRadius(sp,ep,ip):
     Cx = h
     Cy = k
     radius = r
-    return wx.Point(Cx,Cy), radius
+    # wx.LogMessage('cx: ' + str(Cx) + ', cy: ' + str(Cy))
+    return wx.RealPoint(Cx,Cy), radius
 #
 def getAngleRadians(p1,p2):
     #return math.degrees(math.atan2((p1.y-p2.y),(p1.x-p2.x)))
@@ -383,4 +384,4 @@ def rotatePoint(r,sa,da,c):
     # sa, da in radians
     x = c.x - math.cos(sa+da) * r
     y = c.y - math.sin(sa+da) * r
-    return wx.Point(x,y)
+    return wx.RealPoint(x,y)

--- a/via_fence_generator/viafence.py
+++ b/via_fence_generator/viafence.py
@@ -373,13 +373,12 @@ def getCircleCenterRadius(sp,ep,ip):
     Cx = h
     Cy = k
     radius = r
-    # wx.LogMessage('cx: ' + str(Cx) + ', cy: ' + str(Cy))
     return wx.RealPoint(Cx,Cy), radius
-#
+
 def getAngleRadians(p1,p2):
     #return math.degrees(math.atan2((p1.y-p2.y),(p1.x-p2.x)))
     return (math.atan2((p1.y-p2.y),(p1.x-p2.x)))
-#
+
 def rotatePoint(r,sa,da,c):
     # sa, da in radians
     x = c.x - math.cos(sa+da) * r


### PR DESCRIPTION
When generating via fences for arc traces in KiCad 6, there is 2 functions which use `wx.Point` these point instances are instantiated with `float`s instead of `int`s which seems to no longer be supported in wx, as part of this PR I have changed the `wx.Point` usage to be `wx.RealPoint`.

It is possible that this is not supported in older versions of wx and we may need to check peoples versions, but I have not checked yet?