### PR TITLE
Solder Mask Expander: invalid input now properly exits Run.

### DIFF
--- a/trace_solder_expander/trace_solder_expander.py
+++ b/trace_solder_expander/trace_solder_expander.py
@@ -157,8 +157,11 @@ class Solder_Expander(pcbnew.ActionPlugin):
             aParameters.m_checkBoxD.Hide()
             aParameters.m_staticText10111.Hide()
         modal_result = aParameters.ShowModal()
-        clearance = FromMM(self.CheckInput(aParameters.m_clearanceMM.GetValue(), "extra clearance from track width"))
-        
+        clearance = self.CheckInput(aParameters.m_clearanceMM.GetValue(), "extra clearance from track width")
+        if clearance is None:
+            return
+        clearance = FromMM(clearance)
+
         if not(hasattr(pcbnew,'DRAWSEGMENT')):
         #if hasattr(pcb, 'm_Uuid'):
             aParameters.m_buttonDelete.Disable()


### PR DESCRIPTION
Fixed crash when inputing 0 in Solder Mask Expander #39 with a simple return statement if the input is not valid.